### PR TITLE
dinit.sh is a must-have step

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Alternatively, you can build the project using the provided Docker file.
 One time initialization:
 
 ```shell
+./dinit.sh
 ./dcmake.sh
 ```
 


### PR DESCRIPTION
missing dinit.sh in readme.
without running dinit.sh, other steps won't work.